### PR TITLE
Message history

### DIFF
--- a/man/lchat.1
+++ b/man/lchat.1
@@ -109,6 +109,8 @@ displayed respectively.
 Toggles the auto scrolling feature on and off.
 .IP "CTRL-R"
 Completely redraws the client.
+.IP "CTRL-P"
+Changes the input to iterate through past messages sent. The up and down arrow keys list through the message history and the enter key will select the displayed entry. The input allows the selected message to be edited before it is sent.
 .PP
 The input window has many of the standard editing keys available. The left, right, home and end keys move the cursor. The delete and backspace keys delete characters accordingly. Finally the insert key toggles the input between insert and overwrite modes.
 
@@ -122,15 +124,6 @@ can eventually lockup the \fBlchatd\fR server.
 
 .SH AUTHOR
 Written by Ron R Wills.
-
-.SH COPYRIGHT
-Copyright © 2018-2020 Ron R Wills <ron@digitalcombine.ca>.
-.br
-License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
-.br
-This is free software: you are free  to  change  and  redistribute  it.
-.br
-There is NO WARRANTY, to the extent permitted by law.
 
 .SH "SEE ALSO"
 .BR lchatd (1).

--- a/man/lchatd.1
+++ b/man/lchatd.1
@@ -81,14 +81,5 @@ Displays a very brief help screen.
 .SH AUTHOR
 Written by Ron R Wills.
 
-.SH COPYRIGHT
-Copyright © 2018-2020 Ron R Wills <ron@digitalcombine.ca>.
-.br
-License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
-.br
-This is free software: you are free  to  change  and  redistribute  it.
-.br
-There is NO WARRANTY, to the extent permitted by law.
-
 .SH "SEE ALSO"
 .BR lchat (1).

--- a/src/lchat.cpp
+++ b/src/lchat.cpp
@@ -56,6 +56,7 @@ static int C_PRVMSG     = 6;
 static int C_STATUS     = 7;
 static int C_STATUS_ON  = 8;
 static int C_STATUS_OFF = 9;
+static int C_HISTORY    = 10;
 
 // Global data.
 static sockets::iostream chatio;
@@ -153,7 +154,7 @@ private:
   userlist *_userlist;
 };
 
-/**
+/** The chat's input.
  */
 class input : public curs::window, curs::keyboard_event_handler {
 public:
@@ -162,13 +163,21 @@ public:
   void redraw();
 
 protected:
+  // Key event handler.
   void key_event(int ch);
 
 private:
+  // Reference to the chat interface.
   lchat *_lchat;
 
+  // Input string.
   std::string _line;
   size_t _insert;
+
+  // Message history support.
+  std::list<std::string> _history;
+  bool _history_scan;
+  std::list<std::string>::iterator _history_iter;
 };
 
 /**
@@ -289,14 +298,16 @@ bool chat::read_server() {
 
       // User join message.
       if (line.length() > 21) {
-        if (line.compare(line.length() - 21, 21, " has joined the chat.") == 0) {
+        if (line.compare(line.length() - 21, 21,
+                         " has joined the chat.") == 0) {
           chatio << "/who" << std::endl;
         }
       }
 
       // User left message.
       if (line.length() > 19) {
-        if (line.compare(line.length() - 19, 19, " has left the chat.") == 0) {
+        if (line.compare(line.length() - 19, 19,
+                         " has left the chat.") == 0) {
           chatio << "/who" << std::endl;
         }
       }
@@ -502,7 +513,8 @@ void status::redraw() {
   ****************/
 
 input::input(lchat &chat, int x, int y, int width, int height)
-  : curs::window(x, y, width, height), _lchat(&chat), _line(), _insert(0) {
+  : curs::window(x, y, width, height), _lchat(&chat), _line(), _insert(0),
+    _history_scan(false) {
   *this << curs::leaveok(false);
 }
 
@@ -511,9 +523,17 @@ input::input(lchat &chat, int x, int y, int width, int height)
  *****************/
 
 void input::redraw() {
-  *this << curs::erase
-        << curs::cursor(0, 0) << "> " << _line
-        << curs::cursor(_insert + 2, 0) << curs::cursor(true);
+  if (_history_scan) {
+    *this << curs::erase
+          << curs::cursor(0, 0) << "? "
+          << curs::pairon(C_HISTORY) << _line
+          << curs::cursor(_insert + 2, 0) << curs::cursor(true)
+          << curs::pairoff(C_HISTORY);
+  } else {
+    *this << curs::erase
+          << curs::cursor(0, 0) << "> " << _line
+          << curs::cursor(_insert + 2, 0) << curs::cursor(true);
+  }
 }
 
 /********************
@@ -525,92 +545,125 @@ static bool busy = false;
 #define CTRL(c) ((c) & 037)
 
 void input::key_event(int ch) {
-  switch (ch) {
-  case ERR: // Keyboard input timeout
-    if (not busy) usleep(1000);
-    return;
+  if (_history_scan) {
+    switch (ch) {
+    case KEY_UP:
+      if (_history_iter != _history.begin()) --_history_iter;
+      _line = *_history_iter;
+      _insert = _line.length();
+      break;
 
-  case '\n': // Send the line to the server and reset the input.
-    chatio << _line << std::endl;
-    _line = "";
-    _insert = 0;
-    break;
+    case KEY_DOWN:
+      if (_history_iter != _history.end()) ++_history_iter;
+      if (_history_iter != _history.end()) {
+        _line = *_history_iter;
+      } else {
+        _line = "";
+      }
+      _insert = _line.length();
+      break;
 
-  case CTRL('a'):
-    chat::auto_scroll = not chat::auto_scroll;
-    break;
-
-  case CTRL('r'):
-    _lchat->resize_event();
-    break;
-
-  case KEY_BACKSPACE:
-  case '\b':
-  case '\x7f':
-    if (not _line.empty() and _insert > 0) {
-      _line.erase(_insert - 1, 1);
-      _insert--;
+    case '\n':
+      _history_scan = false;
+      break;
     }
-    break;
+  } else {
+    switch (ch) {
+    case ERR: // Keyboard input timeout
+      if (not busy) usleep(1000);
+      return;
 
-  case KEY_DC:
-    if (not _line.empty() and _insert < _line.size()) {
-      _line.erase(_insert, 1);
+    case '\n': // Send the line to the server and reset the input.
+      chatio << _line << std::endl;
+      _history.push_back(_line);
+      while (_history.size() > 100) _history.pop_front();
+      _line = "";
+      _insert = 0;
+      break;
+
+    case CTRL('a'):
+      chat::auto_scroll = not chat::auto_scroll;
+      break;
+
+    case CTRL('p'):
+      _history_scan = true;
+      _history_iter = _history.end();
+      _line = "";
+      _insert = 0;
+      break;
+
+    case CTRL('r'):
+      _lchat->resize_event();
+      break;
+
+    case KEY_BACKSPACE:
+    case '\b':
+    case '\x7f':
+      if (not _line.empty() and _insert > 0) {
+        _line.erase(_insert - 1, 1);
+        _insert--;
+      }
+      break;
+
+    case KEY_DC:
+      if (not _line.empty() and _insert < _line.size()) {
+        _line.erase(_insert, 1);
+      }
+      break;
+
+    case KEY_IC: // Insert key, toggles insert/overwrite mode
+      insert_mode = (insert_mode ? false : true);
+      break;
+
+    case KEY_UP:
+      _lchat->scroll_chat(lchat::D_UP);
+      break;
+
+    case KEY_DOWN:
+      _lchat->scroll_chat(lchat::D_DOWN);
+      break;
+
+    case KEY_LEFT:
+      if (_insert > 0) _insert--;
+      break;
+
+    case KEY_RIGHT:
+      if (_insert < _line.size()) _insert++;
+      break;
+
+    case KEY_PPAGE: // Page up key
+      _lchat->page_chat(lchat::D_UP);
+      break;
+
+    case KEY_NPAGE: // Page down key
+      _lchat->page_chat(lchat::D_DOWN);
+      break;
+
+    case KEY_HOME:
+      _insert = 0;
+      break;
+
+    case KEY_END:
+      _insert = _line.size();
+      break;
+
+    default:
+      /* XXX Current isprint doesn't work with multibyte unicode
+       * characters, but for the moment our _insert pointers is smart
+       * enough to manage multibyte characters.
+       */
+      if (isprint(ch)) {
+        std::string in;
+        in += ch; // This is sillyness, but it's what C++ wants.
+
+        if (insert_mode or _insert >= _line.size())
+          _line.insert(_insert, in);
+        else
+          _line.replace(_insert, 1, in);
+        _insert++;
+      }
+      break;
     }
-    break;
-
-  case KEY_IC: // Insert key, toggles insert/overwrite mode
-    insert_mode = (insert_mode ? false : true);
-    break;
-
-  case KEY_UP:
-    _lchat->scroll_chat(lchat::D_UP);
-    break;
-
-  case KEY_DOWN:
-    _lchat->scroll_chat(lchat::D_DOWN);
-    break;
-
-  case KEY_LEFT:
-    if (_insert > 0) _insert--;
-    break;
-
-  case KEY_RIGHT:
-    if (_insert < _line.size()) _insert++;
-    break;
-
-  case KEY_PPAGE: // Page up key
-    _lchat->page_chat(lchat::D_UP);
-    break;
-
-  case KEY_NPAGE: // Page down key
-    _lchat->page_chat(lchat::D_DOWN);
-    break;
-
-  case KEY_HOME:
-    _insert = 0;
-    break;
-
-  case KEY_END:
-    _insert = _line.size();
-    break;
-
-  default:
-    /* XXX Current isprint doesn't work with multibyte unicode characters, but
-     * for the moment our _insert pointers is smart enough to manage multibyte
-     * characters.
-     */
-    if (isprint(ch)) {
-      std::string in;
-      in += ch; // This is sillyness, but it's what C++ wants.
-
-      if (insert_mode or _insert >= _line.size())
-        _line.insert(_insert, in);
-      else
-        _line.replace(_insert, 1, in);
-      _insert++;
-    }
-    break;
   }
 
   redraw();
@@ -651,6 +704,7 @@ lchat::lchat()
                         curs::colors::BLUE);
     curs::colors::pair(C_STATUS_OFF, curs::colors::RED,
                         curs::colors::BLUE);
+    curs::colors::pair(C_HISTORY, curs::colors::CYAN, -1);
   }
 
   _draw();


### PR DESCRIPTION
The input can change to history mode with _CTRL-P_. The following is done when the input changes to history mode:
- The input prompt changes from > to ?
- The color of the messages changes to CYAN
- The up and down arrow keys iterates through the history
- The enter selects the displayed message and returns the input back to normal.

When a message is selected it is allowed to be edited before it is sent to the chat.